### PR TITLE
Update flask_dotenv.py

### DIFF
--- a/flask_dotenv.py
+++ b/flask_dotenv.py
@@ -37,8 +37,10 @@ class DotEnv(object):
         with open(env_file, "r") as f:
             for line in f:
                 try:
+                    line = line.lstrip()
+                    if line.startswith('export'):
+                        line = line.replace('export', '',  count=1)
                     key, val = line.strip().split('=', 1)
-                    key = key.lstrip('export ')
                 except ValueError:  # Take care of blank or comment lines
                     pass
                 else:


### PR DESCRIPTION
Small fix for keys that start with lowercased letters 'export'
>>>'export exp=ort'.lstrip('export ')
'=ort'